### PR TITLE
Bugfix for "ReferenceError: red is not defined"

### DIFF
--- a/hexSorter.js
+++ b/hexSorter.js
@@ -193,6 +193,9 @@ module.exports = {
         let g2;
         let b1;
         let b2;
+        let red;
+        let green;
+        let blue;
         hex1 = this.hexValueSanitize(hex1);
         hex2 = this.hexValueSanitize(hex2);
         if (hex1.length == 3) {


### PR DESCRIPTION
When calling colorMixer() I got a ReferenceError. It looks like you forgot to define the red/green/blue variables like you do it in the other functions.